### PR TITLE
Link the Twitter settings page

### DIFF
--- a/src/Welcome.js
+++ b/src/Welcome.js
@@ -9,9 +9,10 @@ export default () => (
       <p>Make a nice graph of your Twitter activity.</p>
       <ol>
         <li>
-          <b>Request your Twitter archive.</b> Go to “Settings and privacy”,
-          scroll down and click “Request your archive”. Twitter will email you a
-          link to a zip file.
+          <b>Request your Twitter archive.</b> Go to
+          <a href="https://twitter.com/settings/account" target="_blank">“Settings
+          and privacy”</a>, scroll down and click “Request your archive”. Twitter
+          will email you a link to a zip file.
         </li>
         <li>
           <b>Download the archive.</b>


### PR DESCRIPTION
The twitter settings page is user-independent so can be linked directly, thus saving people clicking around themselves trying to find it.

I've not actually tested this because how on earth do you even build & run this modern javascript nonsense. Bring back Makefiles.